### PR TITLE
internal: remove unneeded boxes

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -437,7 +437,7 @@ impl<'old, 'new, 'bufs, T: DiffableStr + ?Sized + 'old + 'new> TextDiff<'old, 'n
     pub fn iter_changes<'x, 'slf>(
         &'slf self,
         op: &DiffOp,
-    ) -> impl Iterator<Item = Change<'x, T>> + 'slf
+    ) -> impl Iterator<Item = Change<'x, T>> + '_
     where
         'x: 'slf,
         'old: 'x,
@@ -462,16 +462,13 @@ impl<'old, 'new, 'bufs, T: DiffableStr + ?Sized + 'old + 'new> TextDiff<'old, 'n
     ///
     /// This is a shortcut for combining [`TextDiff::ops`] with
     /// [`TextDiff::iter_changes`].
-    pub fn iter_all_changes<'x, 'slf>(&'slf self) -> impl Iterator<Item = Change<'x, T>> + 'slf
+    pub fn iter_all_changes<'x, 'slf>(&'slf self) -> impl Iterator<Item = Change<'x, T>> + '_
     where
-        'x: 'slf,
+        'x: 'slf + 'old + 'new,
         'old: 'x,
         'new: 'x,
     {
-        // unclear why this needs Box::new here.  It seems to infer some really
-        // odd lifetimes I can't figure out how to work with.
-        Box::new(self.ops().iter().flat_map(move |op| self.iter_changes(&op)))
-            as Box<dyn Iterator<Item = _>>
+        self.ops().iter().flat_map(move |op| self.iter_changes(&op))
     }
 
     /// Utility to return a unified diff formatter.
@@ -492,14 +489,12 @@ impl<'old, 'new, 'bufs, T: DiffableStr + ?Sized + 'old + 'new> TextDiff<'old, 'n
     ///
     /// Requires the `inline` feature.
     #[cfg(feature = "inline")]
-    pub fn iter_inline_changes<'x, 'slf>(
+    pub fn iter_inline_changes<'slf>(
         &'slf self,
         op: &DiffOp,
-    ) -> impl Iterator<Item = InlineChange<'x, T>> + 'slf
+    ) -> impl Iterator<Item = InlineChange<'slf, T>> + '_
     where
-        'x: 'slf,
-        'old: 'x,
-        'new: 'x,
+        'slf: 'old + 'new,
     {
         inline::iter_inline_changes(self, op)
     }


### PR DESCRIPTION
You mentioned [here](https://github.com/colin-kiegel/rust-pretty-assertions/pull/51#issuecomment-778853965) that you had some `Box`es you thought were unnecessary - I think you were almost there, I pretty much just shuffled around the lifetimes you already had and got something that worked.

The main hurdle was:

```log
error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
   --> src/text/mod.rs:465:54
    |
465 |     pub fn iter_all_changes<'x, 'slf>(&'slf self) -> impl Iterator<Item = Change<'x, T>> + 'slf
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: hidden type `FlatMap<std::slice::Iter<'slf, types::DiffOp>, impl Iterator, [closure@src/text/mod.rs:471:36: 471:68]>` captures the lifetime `'new` as defined on the impl at 383:12
   --> src/text/mod.rs:383:12
    |
383 | impl<'old, 'new, 'bufs, T: DiffableStr + ?Sized + 'old + 'new> TextDiff<'old, 'new, 'bufs, T> {
    |            ^^^^

```

Which states that:
- the type we're hiding with `impl Iterator`, `Flatmap`, is capturing the lifetime `'new`
- but our type signature for `impl Iterator` doesn't contain the lifetime `'new`

The only lifetime we use in `impl Iterator` is `'x`. So all we need to do is add an additional bound that `'x: 'new`, which then means that `'new` **is implicitly used in our final type signature**.

The rest is just adding lifetime bounds on other functions that call this one until the compiler is happy.