### PR TITLE
Added deadlines to all algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to similar are documented here.
 
 * Performance improvements for the LCS algorithm.
 * Small performance improvments by adding an early opt-out for and inline highlighting.
+* Added deadlines to all diffing algorithms to bail early.
+* Deprecated slice diffing methods in the individual algorithm modules.
 
 ## 1.2.2
 

--- a/src/algorithms/capture.rs
+++ b/src/algorithms/capture.rs
@@ -94,7 +94,7 @@ impl DiffHook for Capture {
 
 #[test]
 fn test_capture_hook_grouping() {
-    use crate::algorithms::{myers, Replace};
+    use crate::algorithms::{diff_slices, Algorithm, Replace};
 
     let rng = (1..100).collect::<Vec<_>>();
     let mut rng_new = rng.clone();
@@ -104,7 +104,7 @@ fn test_capture_hook_grouping() {
     rng_new[34] = 1000;
 
     let mut d = Replace::new(Capture::new());
-    myers::diff_slices(&mut d, &rng, &rng_new).unwrap();
+    diff_slices(Algorithm::Myers, &mut d, &rng, &rng_new).unwrap();
 
     let ops = d.into_inner().into_grouped_ops(3);
     let tags = ops

--- a/src/algorithms/lcs.rs
+++ b/src/algorithms/lcs.rs
@@ -4,18 +4,47 @@
 //! * space `O(MN)`
 use std::collections::BTreeMap;
 use std::ops::{Index, Range};
+use std::time::Instant;
 
 use crate::algorithms::DiffHook;
 
 /// Hunt–McIlroy / Hunt–Szymanski LCS diff algorithm.
 ///
 /// Diff `old`, between indices `old_range` and `new` between indices `new_range`.
+///
+/// This diff is done with an optional deadline that defines the maximal
+/// execution time permitted before it bails and falls back to an very bad
+/// approximation.  Deadlines with LCS do not make a lot of sense and should
+/// not be used.
 pub fn diff<Old, New, D>(
     d: &mut D,
     old: &Old,
     old_range: Range<usize>,
     new: &New,
     new_range: Range<usize>,
+) -> Result<(), D::Error>
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    D: DiffHook,
+    New::Output: PartialEq<Old::Output>,
+{
+    diff_deadline(d, old, old_range, new, new_range, None)
+}
+
+/// Hunt–McIlroy / Hunt–Szymanski LCS diff algorithm.
+///
+/// Diff `old`, between indices `old_range` and `new` between indices `new_range`.
+///
+/// This diff is done with an optional deadline that defines the maximal
+/// execution time permitted before it bails and falls back to an approximation.
+pub fn diff_deadline<Old, New, D>(
+    d: &mut D,
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+    deadline: Option<Instant>,
 ) -> Result<(), D::Error>
 where
     Old: Index<usize> + ?Sized,
@@ -44,11 +73,12 @@ where
         .take_while(|x| new[x.1] == old[x.0])
         .count();
 
-    let table = make_table(
+    let maybe_table = make_table(
         old,
         prefix_len..(old_range.len() - suffix_len),
         new,
         prefix_len..(new_range.len() - suffix_len),
+        deadline,
     );
     let mut old_idx = 0;
     let mut new_idx = 0;
@@ -59,23 +89,30 @@ where
         d.equal(old_range.start, new_range.start, prefix_len)?;
     }
 
-    while new_idx < new_len && old_idx < old_len {
+    if let Some(table) = maybe_table {
+        while new_idx < new_len && old_idx < old_len {
+            let old_orig_idx = old_range.start + prefix_len + old_idx;
+            let new_orig_idx = new_range.start + prefix_len + new_idx;
+
+            if new[new_orig_idx] == old[old_orig_idx] {
+                d.equal(old_orig_idx, new_orig_idx, 1)?;
+                old_idx += 1;
+                new_idx += 1;
+            } else if table.get(&(new_idx, old_idx + 1)).map_or(0, |&x| x)
+                >= table.get(&(new_idx + 1, old_idx)).map_or(0, |&x| x)
+            {
+                d.delete(old_orig_idx, 1, new_orig_idx)?;
+                old_idx += 1;
+            } else {
+                d.insert(old_orig_idx, new_orig_idx, 1)?;
+                new_idx += 1;
+            }
+        }
+    } else {
         let old_orig_idx = old_range.start + prefix_len + old_idx;
         let new_orig_idx = new_range.start + prefix_len + new_idx;
-
-        if new[new_orig_idx] == old[old_orig_idx] {
-            d.equal(old_orig_idx, new_orig_idx, 1)?;
-            old_idx += 1;
-            new_idx += 1;
-        } else if table.get(&(new_idx, old_idx + 1)).map_or(0, |&x| x)
-            >= table.get(&(new_idx + 1, old_idx)).map_or(0, |&x| x)
-        {
-            d.delete(old_orig_idx, 1, new_orig_idx)?;
-            old_idx += 1;
-        } else {
-            d.insert(old_orig_idx, new_orig_idx, 1)?;
-            new_idx += 1;
-        }
+        d.delete(old_orig_idx, old_len, new_orig_idx)?;
+        d.insert(old_orig_idx, new_orig_idx, new_len)?;
     }
 
     if old_idx < old_len {
@@ -107,6 +144,10 @@ where
 }
 
 /// Shortcut for diffing slices.
+#[deprecated(
+    since = "1.4.0",
+    note = "slice utility function is now only available via similar::algorithms::diff_slices"
+)]
 pub fn diff_slices<D, T>(d: &mut D, old: &[T], new: &[T]) -> Result<(), D::Error>
 where
     D: DiffHook,
@@ -120,7 +161,8 @@ fn make_table<Old, New>(
     old_range: Range<usize>,
     new: &New,
     new_range: Range<usize>,
-) -> BTreeMap<(usize, usize), u32>
+    deadline: Option<Instant>,
+) -> Option<BTreeMap<(usize, usize), u32>>
 where
     Old: Index<usize> + ?Sized,
     New: Index<usize> + ?Sized,
@@ -131,6 +173,13 @@ where
     let mut table = BTreeMap::new();
 
     for i in (0..new_len).rev() {
+        // are we running for too long?  give up on the table
+        if let Some(deadline) = deadline {
+            if Instant::now() > deadline {
+                return None;
+            }
+        }
+
         for j in (0..old_len).rev() {
             let val = if new[i] == old[j] {
                 table.get(&(i + 1, j + 1)).map_or(0, |&x| x) + 1
@@ -146,12 +195,12 @@ where
         }
     }
 
-    table
+    Some(table)
 }
 
 #[test]
 fn test_table() {
-    let table = make_table(&vec![2, 3], 0..2, &vec![0, 1, 2], 0..3);
+    let table = make_table(&vec![2, 3], 0..2, &vec![0, 1, 2], 0..3, None).unwrap();
     let expected = {
         let mut m = BTreeMap::new();
         m.insert((1, 0), 1);
@@ -168,7 +217,7 @@ fn test_diff() {
     let b: &[usize] = &[0, 1, 2, 9, 4];
 
     let mut d = crate::algorithms::Replace::new(crate::algorithms::Capture::new());
-    diff_slices(&mut d, a, b).unwrap();
+    diff(&mut d, a, 0..a.len(), b, 0..b.len()).unwrap();
     insta::assert_debug_snapshot!(d.into_inner().ops());
 }
 
@@ -178,7 +227,7 @@ fn test_contiguous() {
     let b: &[usize] = &[0, 1, 2, 8, 9, 4, 4, 7];
 
     let mut d = crate::algorithms::Replace::new(crate::algorithms::Capture::new());
-    diff_slices(&mut d, a, b).unwrap();
+    diff(&mut d, a, 0..a.len(), b, 0..b.len()).unwrap();
     insta::assert_debug_snapshot!(d.into_inner().ops());
 }
 
@@ -188,6 +237,6 @@ fn test_pat() {
     let b: &[usize] = &[0, 1, 4, 5, 8, 9];
 
     let mut d = crate::algorithms::Capture::new();
-    diff_slices(&mut d, a, b).unwrap();
+    diff(&mut d, a, 0..a.len(), b, 0..b.len()).unwrap();
     insta::assert_debug_snapshot!(d.ops());
 }

--- a/src/algorithms/myers.rs
+++ b/src/algorithms/myers.rs
@@ -329,7 +329,7 @@ where
     None
 }
 
-#[allowgi(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn conquer<Old, New, D>(
     d: &mut D,
     old: &Old,

--- a/src/algorithms/myers.rs
+++ b/src/algorithms/myers.rs
@@ -329,7 +329,7 @@ where
     None
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allowgi(clippy::too_many_arguments)]
 fn conquer<Old, New, D>(
     d: &mut D,
     old: &Old,
@@ -455,6 +455,7 @@ fn test_pat() {
 #[test]
 fn test_deadline_reached() {
     use std::ops::Index;
+    use std::time::Duration;
 
     let a = (0..100).collect::<Vec<_>>();
     let mut b = (0..100).collect::<Vec<_>>();

--- a/src/algorithms/replace.rs
+++ b/src/algorithms/replace.rs
@@ -134,7 +134,7 @@ impl<D: DiffHook> DiffHook for Replace<D> {
 
 #[test]
 fn test_mayers_replace() {
-    use crate::algorithms::myers;
+    use crate::algorithms::{diff_slices, Algorithm};
     let a: &[&str] = &[
         ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n",
         "a\n",
@@ -159,7 +159,7 @@ fn test_mayers_replace() {
     ];
 
     let mut d = Replace::new(crate::algorithms::Capture::new());
-    myers::diff_slices(&mut d, a, b).unwrap();
+    diff_slices(Algorithm::Myers, &mut d, a, b).unwrap();
 
     insta::assert_debug_snapshot!(&d.into_inner().ops(), @r###"
     [
@@ -196,11 +196,13 @@ fn test_mayers_replace() {
 
 #[test]
 fn test_replace() {
+    use crate::algorithms::{diff_slices, Algorithm};
+
     let a: &[usize] = &[0, 1, 2, 3, 4];
     let b: &[usize] = &[0, 1, 2, 7, 8, 9];
 
     let mut d = Replace::new(crate::algorithms::Capture::new());
-    crate::algorithms::myers::diff_slices(&mut d, a, b).unwrap();
+    diff_slices(Algorithm::Myers, &mut d, a, b).unwrap();
     insta::assert_debug_snapshot!(d.into_inner().ops(), @r###"
     [
         Equal {

--- a/src/algorithms/snapshots/similar__algorithms__myers__deadline_reached.snap
+++ b/src/algorithms/snapshots/similar__algorithms__myers__deadline_reached.snap
@@ -1,0 +1,22 @@
+---
+source: src/algorithms/myers.rs
+expression: d.into_inner().ops()
+---
+[
+    Equal {
+        old_index: 0,
+        new_index: 0,
+        len: 10,
+    },
+    Replace {
+        old_index: 10,
+        old_len: 41,
+        new_index: 10,
+        new_len: 41,
+    },
+    Equal {
+        old_index: 51,
+        new_index: 51,
+        len: 49,
+    },
+]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,13 +1,15 @@
 use std::hash::Hash;
 use std::ops::{Index, Range};
+use std::time::Instant;
 
-use crate::algorithms::{diff, diff_slices, Capture, Replace};
+use crate::algorithms::{diff_deadline, diff_slices_deadline, Capture, Replace};
 use crate::{Algorithm, DiffOp};
 
 /// Creates a diff between old and new with the given algorithm capturing the ops.
 ///
-/// This is like [`diff`] but instead of using an arbitrary hook this will
-/// always use [`Replace`] + [`Capture`] and return the captured [`DiffOp`]s.
+/// This is like [`diff`](crate::algorithms::diff) but instead of using an
+/// arbitrary hook this will always use [`Replace`] + [`Capture`] and return the
+/// captured [`DiffOp`]s.
 pub fn capture_diff<Old, New>(
     alg: Algorithm,
     old: &Old,
@@ -21,8 +23,28 @@ where
     Old::Output: Hash + Eq + Ord,
     New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
 {
+    capture_diff_deadline(alg, old, old_range, new, new_range, None)
+}
+
+/// Creates a diff between old and new with the given algorithm capturing the ops.
+///
+/// Works like [`capture_diff`] but with an optional deadline.
+pub fn capture_diff_deadline<Old, New>(
+    alg: Algorithm,
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+    deadline: Option<Instant>,
+) -> Vec<DiffOp>
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    Old::Output: Hash + Eq + Ord,
+    New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
+{
     let mut d = Replace::new(Capture::new());
-    diff(alg, &mut d, old, old_range, new, new_range).unwrap();
+    diff_deadline(alg, &mut d, old, old_range, new, new_range, deadline).unwrap();
     d.into_inner().into_ops()
 }
 
@@ -31,8 +53,23 @@ pub fn capture_diff_slices<T>(alg: Algorithm, old: &[T], new: &[T]) -> Vec<DiffO
 where
     T: Eq + Hash + Ord,
 {
+    capture_diff_slices_deadline(alg, old, new, None)
+}
+
+/// Creates a diff between old and new with the given algorithm capturing the ops.
+///
+/// Works like [`capture_diff_slices`] but with an optional deadline.
+pub fn capture_diff_slices_deadline<T>(
+    alg: Algorithm,
+    old: &[T],
+    new: &[T],
+    deadline: Option<Instant>,
+) -> Vec<DiffOp>
+where
+    T: Eq + Hash + Ord,
+{
     let mut d = Replace::new(Capture::new());
-    diff_slices(alg, &mut d, old, new).unwrap();
+    diff_slices_deadline(alg, &mut d, old, new, deadline).unwrap();
     d.into_inner().into_ops()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,22 @@
 //! As the [`TextDiff::grouped_ops`] method can isolate clusters of changes
 //! this even works for very long files if paired with this method.
 //!
+//! # Deadlines and Performance
+//!
+//! For large and very distinct inputs the algorithms as implemented can take
+//! a very, very long time to execute.  Too long to make sense in practice.
+//! To work around this issue all diffing algorithms also provide a version
+//! that accepts a deadline which is the point in time as defined by an
+//! [`Instant`](std::time::Instant) after which the algorithm should give up.
+//! What giving up means depends on the algorithm.  For instance due to the
+//! recursive, divide and conquer nature of Myer's diff you will still get a
+//! pretty decent diff in many cases when a deadline is reached.  Whereas on the
+//! other hand the LCS diff is unlikely to give any decent results in such a
+//! situation.
+//!
+//! The [`TextDiff`] type also lets you configure a deadline and/or timeout
+//! when performing a text diff.
+//!
 //! # Feature Flags
 //!
 //! The crate by default does not have any dependencies however for some use


### PR DESCRIPTION
This adds a deadline to all algorithms which lets one bail in a fixed amount of time.

The idea here is that this is a relatively cheap way to make a diff terminate in a certain amount of time when a bad case is encountered.

Fixes #17 