### PR TITLE
Update `bstr` to 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ inline = ["text"]
 
 # this annoyingly currently also turns on bstr and not just bstr/unicode
 # unclear if this is fixable
-unicode = ["text", "unicode-segmentation", "bstr/unicode"]
+unicode = ["text", "unicode-segmentation", "bstr/unicode", "bstr/std"]
 bytes = ["bstr", "text"]
 
 [dev-dependencies]
@@ -33,7 +33,7 @@ serde_json = "1.0.68"
 
 [dependencies]
 unicode-segmentation = { version = "1.7.1", optional = true }
-bstr = { version = "0.2.14", optional = true, default-features = false }
+bstr = { version = "1.0.1", optional = true, default-features = false }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 
 [[example]]


### PR DESCRIPTION
The only impacting breaking change seems to be that enabling unicode support requires enabling std.