### PR TITLE
doc(inline/iter_strings_lossy): describe different behaviors

### DIFF
--- a/src/text/inline.rs
+++ b/src/text/inline.rs
@@ -147,6 +147,12 @@ impl<'s, T: DiffableStr + ?Sized> InlineChange<'s, T> {
     ///
     /// Each item is a tuple in the form `(emphasized, value)` where `emphasized`
     /// is true if it should be highlighted as an inline diff.
+    ///
+    /// By default, words are split by whitespace, which results in coarser diff.
+    /// For example: `"f(x) y"` is tokenized as `["f(x)", "y"]`.
+    ///
+    /// If you want it to tokenized instead as `["f", "(", "x", ")"]`.
+    /// You should enable the `"unicode"` flag.
     pub fn iter_strings_lossy(&self) -> impl Iterator<Item = (bool, Cow<'_, str>)> {
         self.values()
             .iter()

--- a/src/text/inline.rs
+++ b/src/text/inline.rs
@@ -151,8 +151,8 @@ impl<'s, T: DiffableStr + ?Sized> InlineChange<'s, T> {
     /// By default, words are split by whitespace, which results in coarser diff.
     /// For example: `"f(x) y"` is tokenized as `["f(x)", "y"]`.
     ///
-    /// If you want it to tokenized instead as `["f", "(", "x", ")"]`.
-    /// You should enable the `"unicode"` flag.
+    /// If you want it to be tokenized instead as `["f(", "x", ")"]`,
+    /// you should enable the `"unicode"` flag.
     pub fn iter_strings_lossy(&self) -> impl Iterator<Item = (bool, Cow<'_, str>)> {
         self.values()
             .iter()


### PR DESCRIPTION
## Preface
When I copied the code from the [terminal-inline](https://github.com/mitsuhiko/similar/blob/main/examples/terminal-inline.rs) example, I expected it to work as shown in the README Screenshot:

![image](https://github.com/mitsuhiko/similar/assets/23183656/75c7d317-cf4c-40aa-ba78-43c985f26ec0)


However, when I copied the code to my own project, it behaved differently. Specifically, the word was split by whitespace instead of non-alphanumeric characters.

It took me a while to figure out that the culprit was the `unicode` flag, which I did not enable in my project.

## Reference
- https://github.com/mitsuhiko/similar/blob/47f46257d4553d3e8a9cc82e37786f05a64b005b/src/text/abstraction.rs#L68-L74