### PR TITLE
Remove unecessary Ord bound

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -71,8 +71,8 @@ where
     Old: Index<usize> + ?Sized,
     New: Index<usize> + ?Sized,
     D: DiffHook,
-    Old::Output: Hash + Eq + Ord,
-    New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
+    Old::Output: Hash + Eq,
+    New::Output: PartialEq<Old::Output> + Hash + Eq,
 {
     diff_deadline(alg, d, old, old_range, new, new_range, None)
 }
@@ -99,8 +99,8 @@ where
     Old: Index<usize> + ?Sized,
     New: Index<usize> + ?Sized,
     D: DiffHook,
-    Old::Output: Hash + Eq + Ord,
-    New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
+    Old::Output: Hash + Eq,
+    New::Output: PartialEq<Old::Output> + Hash + Eq,
 {
     match alg {
         Algorithm::Myers => myers::diff_deadline(d, old, old_range, new, new_range, deadline),
@@ -113,7 +113,7 @@ where
 pub fn diff_slices<D, T>(alg: Algorithm, d: &mut D, old: &[T], new: &[T]) -> Result<(), D::Error>
 where
     D: DiffHook,
-    T: Eq + Hash + Ord,
+    T: Eq + Hash,
 {
     diff(alg, d, old, 0..old.len(), new, 0..new.len())
 }
@@ -128,7 +128,7 @@ pub fn diff_slices_deadline<D, T>(
 ) -> Result<(), D::Error>
 where
     D: DiffHook,
-    T: Eq + Hash + Ord,
+    T: Eq + Hash,
 {
     diff_deadline(alg, d, old, 0..old.len(), new, 0..new.len(), deadline)
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -20,8 +20,8 @@ pub fn capture_diff<Old, New>(
 where
     Old: Index<usize> + ?Sized,
     New: Index<usize> + ?Sized,
-    Old::Output: Hash + Eq + Ord,
-    New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
+    Old::Output: Hash + Eq,
+    New::Output: PartialEq<Old::Output> + Hash + Eq,
 {
     capture_diff_deadline(alg, old, old_range, new, new_range, None)
 }
@@ -40,8 +40,8 @@ pub fn capture_diff_deadline<Old, New>(
 where
     Old: Index<usize> + ?Sized,
     New: Index<usize> + ?Sized,
-    Old::Output: Hash + Eq + Ord,
-    New::Output: PartialEq<Old::Output> + Hash + Eq + Ord,
+    Old::Output: Hash + Eq,
+    New::Output: PartialEq<Old::Output> + Hash + Eq,
 {
     let mut d = Compact::new(Replace::new(Capture::new()), old, new);
     diff_deadline(alg, &mut d, old, old_range, new, new_range, deadline).unwrap();
@@ -51,7 +51,7 @@ where
 /// Creates a diff between old and new with the given algorithm capturing the ops.
 pub fn capture_diff_slices<T>(alg: Algorithm, old: &[T], new: &[T]) -> Vec<DiffOp>
 where
-    T: Eq + Hash + Ord,
+    T: Eq + Hash,
 {
     capture_diff_slices_deadline(alg, old, new, None)
 }
@@ -66,7 +66,7 @@ pub fn capture_diff_slices_deadline<T>(
     deadline: Option<Instant>,
 ) -> Vec<DiffOp>
 where
-    T: Eq + Hash + Ord,
+    T: Eq + Hash,
 {
     capture_diff_deadline(alg, old, 0..old.len(), new, 0..new.len(), deadline)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -209,7 +209,7 @@ impl<'x, T: DiffableStr + ?Sized> TextDiffRemapper<'x, T> {
 ///     (ChangeTag::Insert, &["BAZ"][..]),
 /// ]);
 /// ```
-pub fn diff_slices<'x, T: PartialEq + Hash + Ord>(
+pub fn diff_slices<'x, T: PartialEq + Hash + Eq>(
     alg: Algorithm,
     old: &'x [T],
     new: &'x [T],


### PR DESCRIPTION
Hello, I noticed that this bound is not actually required anywhere, and it makes it harder to diff custom types. Please tell me if I'm missing something and that it can't be removed.