### PR TITLE
Update bstr to 1.X

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0.68"
 
 [dependencies]
 unicode-segmentation = { version = "1.7.1", optional = true }
-bstr = { version = "0.2.14", optional = true, default-features = false }
+bstr = { version = "1.0", optional = true, default-features = false }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 
 [[example]]

--- a/src/text/abstraction.rs
+++ b/src/text/abstraction.rs
@@ -318,11 +318,7 @@ mod bytes_support {
         }
 
         fn ends_with_newline(&self) -> bool {
-            if let Some(b'\r') | Some(b'\n') = self.last_byte() {
-                true
-            } else {
-                false
-            }
+            matches!(self.last_byte(), Some(b'\r' | b'\n'))
         }
 
         fn len(&self) -> usize {

--- a/src/text/inline.rs
+++ b/src/text/inline.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "inline")]
 use std::borrow::Cow;
 use std::fmt;
 

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -605,7 +605,7 @@ pub fn get_close_matches<'a, T: DiffableStr + ?Sized>(
         if ratio >= cutoff {
             // we're putting the word itself in reverse in so that matches with
             // the same ratio are ordered lexicographically.
-            matches.push(((ratio * std::u32::MAX as f32) as u32, Reverse(possibility)));
+            matches.push(((ratio * u32::MAX as f32) as u32, Reverse(possibility)));
         }
     }
 


### PR DESCRIPTION
Update the optional `bstr` dependency to `1.X`, plus some clippy fixes.