### PR TITLE
feat: replace std::time with web_time to support WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 authors = [
     "Armin Ronacher <armin.ronacher@active-4.com>",
     "Pierre-Étienne Meunier <pe@pijul.org>",
@@ -35,6 +35,7 @@ serde_json = "1.0.68"
 unicode-segmentation = { version = "1.7.1", optional = true }
 bstr = { version = "1.5.0", optional = true, default-features = false }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
+web-time = "1.1"
 
 [[example]]
 name = "patience"

--- a/src/algorithms/lcs.rs
+++ b/src/algorithms/lcs.rs
@@ -4,7 +4,7 @@
 //! * space `O(MN)`
 use std::collections::BTreeMap;
 use std::ops::{Index, Range};
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::algorithms::utils::{common_prefix_len, common_suffix_len, is_empty_range};
 use crate::algorithms::DiffHook;

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -41,7 +41,7 @@ pub(crate) mod utils;
 
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
+use web_time::Instant;
 
 pub use capture::Capture;
 pub use compact::Compact;

--- a/src/algorithms/myers.rs
+++ b/src/algorithms/myers.rs
@@ -20,7 +20,7 @@
 //! For potential improvements here see [similar#15](https://github.com/mitsuhiko/similar/issues/15).
 
 use std::ops::{Index, IndexMut, Range};
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::algorithms::utils::{common_prefix_len, common_suffix_len, is_empty_range};
 use crate::algorithms::DiffHook;
@@ -378,7 +378,7 @@ fn test_pat() {
 #[test]
 fn test_deadline_reached() {
     use std::ops::Index;
-    use std::time::Duration;
+    use web_time::Duration;
 
     let a = (0..100).collect::<Vec<_>>();
     let mut b = (0..100).collect::<Vec<_>>();

--- a/src/algorithms/patience.rs
+++ b/src/algorithms/patience.rs
@@ -10,7 +10,7 @@
 //! by Pierre-Étienne Meunier.
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::algorithms::{myers, DiffHook, NoFinishHook, Replace};
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
+use web_time::Instant;
 
 use crate::algorithms::{diff_deadline, Capture, Compact, Replace};
 use crate::{Algorithm, DiffOp};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //! a very, very long time to execute.  Too long to make sense in practice.
 //! To work around this issue all diffing algorithms also provide a version
 //! that accepts a deadline which is the point in time as defined by an
-//! [`Instant`](std::time::Instant) after which the algorithm should give up.
+//! [`Instant`](web_time::Instant) after which the algorithm should give up.
 //! What giving up means depends on the algorithm.  For instance due to the
 //! recursive, divide and conquer nature of Myer's diff you will still get a
 //! pretty decent diff in many cases when a deadline is reached.  Whereas on the

--- a/src/text/inline.rs
+++ b/src/text/inline.rs
@@ -6,7 +6,7 @@ use crate::types::{Algorithm, Change, ChangeTag, DiffOp, DiffTag};
 use crate::{capture_diff_deadline, get_diff_ratio};
 
 use std::ops::Index;
-use std::time::Instant;
+use web_time::Instant;
 
 use super::utils::upper_seq_ratio;
 

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 mod abstraction;
 #[cfg(feature = "inline")]


### PR DESCRIPTION
`std::time` doesn't support the WASM target. This update allows to use the crate in WASM targeted builds.