### PR TITLE
Add wasm32_web_time feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 default = ["text"]
 text = []
 inline = ["text"]
-
+wasm32_web_time = ["web-time"]
 unicode = ["text", "unicode-segmentation", "bstr?/unicode", "bstr?/std"]
 bytes = ["bstr", "text"]
 
@@ -35,6 +35,7 @@ serde_json = "1.0.68"
 unicode-segmentation = { version = "1.7.1", optional = true }
 bstr = { version = "1.5.0", optional = true, default-features = false }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
+web-time = { version = "1.1", optional = true }
 
 [[example]]
 name = "patience"

--- a/src/algorithms/lcs.rs
+++ b/src/algorithms/lcs.rs
@@ -4,10 +4,10 @@
 //! * space `O(MN)`
 use std::collections::BTreeMap;
 use std::ops::{Index, Range};
-use std::time::Instant;
 
 use crate::algorithms::utils::{common_prefix_len, common_suffix_len, is_empty_range};
 use crate::algorithms::DiffHook;
+use crate::Instant;
 
 /// LCS diff algorithm.
 ///

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -41,8 +41,8 @@ pub(crate) mod utils;
 
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
 
+use crate::Instant;
 pub use capture::Capture;
 pub use compact::Compact;
 pub use hook::{DiffHook, NoFinishHook};

--- a/src/algorithms/myers.rs
+++ b/src/algorithms/myers.rs
@@ -20,10 +20,10 @@
 //! For potential improvements here see [similar#15](https://github.com/mitsuhiko/similar/issues/15).
 
 use std::ops::{Index, IndexMut, Range};
-use std::time::Instant;
 
 use crate::algorithms::utils::{common_prefix_len, common_suffix_len, is_empty_range};
 use crate::algorithms::DiffHook;
+use crate::Instant;
 
 /// Myers' diff algorithm.
 ///

--- a/src/algorithms/patience.rs
+++ b/src/algorithms/patience.rs
@@ -10,9 +10,9 @@
 //! by Pierre-Étienne Meunier.
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
 
 use crate::algorithms::{myers, DiffHook, NoFinishHook, Replace};
+use crate::Instant;
 
 use super::utils::{unique, UniqueItem};
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,8 @@
 use std::hash::Hash;
 use std::ops::{Index, Range};
-use std::time::Instant;
 
 use crate::algorithms::{diff_deadline, Capture, Compact, Replace};
+use crate::Instant;
 use crate::{Algorithm, DiffOp};
 
 /// Creates a diff between old and new with the given algorithm capturing the ops.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //! a very, very long time to execute.  Too long to make sense in practice.
 //! To work around this issue all diffing algorithms also provide a version
 //! that accepts a deadline which is the point in time as defined by an
-//! [`Instant`](std::time::Instant) after which the algorithm should give up.
+//! [`Instant`](web_time::Instant) after which the algorithm should give up.
 //! What giving up means depends on the algorithm.  For instance due to the
 //! recursive, divide and conquer nature of Myer's diff you will still get a
 //! pretty decent diff in many cases when a deadline is reached.  Whereas on the
@@ -144,6 +144,10 @@
 //!   in a line diff.  This currently also enables the `unicode` feature.
 //! * `serde`: this feature enables serialization to some types in this
 //!   crate.  For enums without payload deserialization is then also supported.
+//! * `wasm32_web_time`: this feature swaps out the use of [`std::time`] for
+//!   the `web_time` crate.  Because this is a change to the public interface,
+//!   this feature must be used with care.  The instant type for this crate is
+//!   then re-exported top-level module.
 #![warn(missing_docs)]
 pub mod algorithms;
 pub mod iter;
@@ -161,3 +165,14 @@ pub use self::common::*;
 #[cfg(feature = "text")]
 pub use self::text::*;
 pub use self::types::*;
+
+/// Internal alias for portability
+#[cfg(not(feature = "wasm32_web_time"))]
+pub(crate) use std::time::Instant;
+
+/// WASM (browser) specific instant type.
+///
+/// This type is only available when the `wasm32_web_time` feature is enabled.  In that
+/// case this is an alias for [`web_time::Instant`].
+#[cfg(feature = "wasm32_web_time")]
+pub use web_time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,12 +112,11 @@
 //! a very, very long time to execute.  Too long to make sense in practice.
 //! To work around this issue all diffing algorithms also provide a version
 //! that accepts a deadline which is the point in time as defined by an
-//! [`Instant`](web_time::Instant) after which the algorithm should give up.
-//! What giving up means depends on the algorithm.  For instance due to the
-//! recursive, divide and conquer nature of Myer's diff you will still get a
-//! pretty decent diff in many cases when a deadline is reached.  Whereas on the
-//! other hand the LCS diff is unlikely to give any decent results in such a
-//! situation.
+//! [`Instant`] after which the algorithm should give up.  What giving up means
+//! depends on the algorithm.  For instance due to the recursive, divide and
+//! conquer nature of Myer's diff you will still get a pretty decent diff in
+//! many cases when a deadline is reached.  Whereas on the other hand the LCS
+//! diff is unlikely to give any decent results in such a situation.
 //!
 //! The [`TextDiff`] type also lets you configure a deadline and/or timeout
 //! when performing a text diff.

--- a/src/text/inline.rs
+++ b/src/text/inline.rs
@@ -3,10 +3,10 @@ use std::fmt;
 
 use crate::text::{DiffableStr, TextDiff};
 use crate::types::{Algorithm, Change, ChangeTag, DiffOp, DiffTag};
+use crate::Instant;
 use crate::{capture_diff_deadline, get_diff_ratio};
 
 use std::ops::Index;
-use std::time::Instant;
 
 use super::utils::upper_seq_ratio;
 

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 mod abstraction;
 #[cfg(feature = "inline")]
@@ -17,6 +17,7 @@ use self::utils::{upper_seq_ratio, QuickSeqRatio};
 use crate::algorithms::IdentifyDistinct;
 use crate::iter::{AllChangesIter, ChangesIter};
 use crate::udiff::UnifiedDiff;
+use crate::Instant;
 use crate::{capture_diff_deadline, get_diff_ratio, group_diff_ops, Algorithm, DiffOp};
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Adds a new feature called `wasm32_web_time` which enables the use of the `web-time` crate instead of `std::time`.

Replaces #71

Refs #46 