### PR TITLE
Fix Myers spelling in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Similar is a dependency free crate for Rust that implements different diffing
 algorithms and high level interfaces for it. It is based on the
 [pijul](https://pijul.org/) implementation of the Patience algorithm and
-inherits some ideas from there. It also incorporates the Myer's diff
+inherits some ideas from there. It also incorporates the Myers' diff
 algorithm which was largely written by Brandon Williams.  This library was
 built for the [insta snapshot testing library](https://insta.rs).
 
@@ -38,7 +38,7 @@ fn main() {
 
 ## What's in the box?
 
-* Myer's diff
+* Myers' diff
 * Patience diff
 * Hunt–McIlroy / Hunt–Szymanski LCS diff
 * Diffing on arbitrary comparable sequences

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@
 //! that accepts a deadline which is the point in time as defined by an
 //! [`Instant`] after which the algorithm should give up.  What giving up means
 //! depends on the algorithm.  For instance due to the recursive, divide and
-//! conquer nature of Myer's diff you will still get a pretty decent diff in
+//! conquer nature of Myers' diff you will still get a pretty decent diff in
 //! many cases when a deadline is reached.  Whereas on the other hand the LCS
 //! diff is unlikely to give any decent results in such a situation.
 //!

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -57,7 +57,7 @@ impl TextDiffConfig {
     /// Sets a deadline for the diff operation.
     ///
     /// By default a diff will take as long as it takes.  For certain diff
-    /// algorithms like Myer's and Patience a maximum running time can be
+    /// algorithms like Myers' and Patience a maximum running time can be
     /// defined after which the algorithm gives up and approximates.
     pub fn deadline(&mut self, deadline: Instant) -> &mut Self {
         self.deadline = Some(Deadline::Absolute(deadline));


### PR DESCRIPTION
Thanks for your work on this project! 😄 

This fixes up the apostrophe placement in the name "Myers", since the "s" is part of the name. (Another option might be to just drop the apostrophe entirely, which would involve a few more changes.)