### PR TITLE
Fix impl Trait lifetime capturing regression in Edition 2024

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -353,7 +353,7 @@ impl DiffOp {
         &self,
         old: &'lookup Old,
         new: &'lookup New,
-    ) -> impl Iterator<Item = (ChangeTag, &'lookup T)>
+    ) -> impl Iterator<Item = (ChangeTag, &'lookup T)> + use<'lookup, Old, New, T>
     where
         T: 'lookup + ?Sized,
         Old: Index<Range<usize>, Output = T> + ?Sized,

--- a/src/udiff.rs
+++ b/src/udiff.rs
@@ -173,7 +173,7 @@ impl<'diff, 'old, 'new, T: DiffableStr + ?Sized> UnifiedDiff<'diff, 'old, 'new, 
     }
 
     /// Iterates over all hunks as configured.
-    pub fn iter_hunks(&self) -> impl Iterator<Item = UnifiedDiffHunk<'diff, 'old, 'new, T>> {
+    pub fn iter_hunks(&self) -> impl Iterator<Item = UnifiedDiffHunk<'diff, 'old, 'new, T>> + use<'diff, 'old, 'new, T> {
         let diff = self.diff;
         let missing_newline_hint = self.missing_newline_hint;
         self.diff

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -164,7 +164,7 @@ impl<'x, T: DiffableStr + ?Sized> TextDiffRemapper<'x, T> {
     ///
     /// This method can panic if the input strings passed to the constructor
     /// are incompatible with the input strings passed to the diffing algorithm.
-    pub fn iter_slices(&self, op: &DiffOp) -> impl Iterator<Item = (ChangeTag, &'x T)> {
+    pub fn iter_slices(&self, op: &DiffOp) -> impl Iterator<Item = (ChangeTag, &'x T)> + use<'x, T> {
         // note: this is equivalent to the code in `DiffOp::iter_slices`.  It is
         // a copy/paste because the slicing currently cannot be well abstracted
         // because of lifetime issues caused by the `Index` trait.


### PR DESCRIPTION
#### Overview
The upgrade to Edition 2024 in `similar` 3.0.0 changed how `impl Trait` captures lifetimes, causing compilation errors in downstream projects like https://github.com/White-Green/semdiff/pull/36.

More details on the new rules can be found here:
- [Edition Guide: RPIT lifetime capture rules](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html)
- [Rust Blog: Rust 1.82.0 - Precise capturing (`use<..>`)](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#precise-capturing-use-syntax)

#### Changes
I've applied the `use<..>` syntax (Precise Capturing) to restore the previous behavior. I assume this regression was unintended, but if this change in behavior was actually intended for 3.0.0, feel free to close this PR.