### PR TITLE
Add proptests for core diff_slices invariants and fix some discovered bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ hashbrown = ["dep:hashbrown"]
 insta = "1.10.0"
 console = "0.15.0"
 serde_json = "1.0.68"
+proptest = "1.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.8.2"

--- a/proptest-regressions/common.txt
+++ b/proptest-regressions/common.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9c0a15e320394495f8519e8e9c9d5bacda44a60773531acf29d43e3320611b5e # shrinks to alg = Histogram, pipeline = Capture, old = [0, 0], new = [1]

--- a/proptest-regressions/common.txt
+++ b/proptest-regressions/common.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 9c0a15e320394495f8519e8e9c9d5bacda44a60773531acf29d43e3320611b5e # shrinks to alg = Histogram, pipeline = Capture, old = [0, 0], new = [1]
+cc 4705ae637c1dc97fa57d93db90ba4e259f2877e20f7f06da69a5ac4070640af3 # shrinks to alg = Lcs, pipeline = Compact, old = [0, 3, 3, 1, 0], new = [0, 0, 3, 0]

--- a/src/algorithms/compact.rs
+++ b/src/algorithms/compact.rs
@@ -147,13 +147,12 @@ where
 }
 
 fn normalize_diff_op_cursors(ops: &mut [DiffOp]) {
+    // Diffs always tile both inputs from the origin, so seed the running
+    // cursors at (0, 0). Seeding from `ops.first()` would propagate stale
+    // indices that swaps in `shift_diff_ops_up`/`shift_diff_ops_down` may
+    // have left on the first op.
     let mut old_cursor = 0;
     let mut new_cursor = 0;
-
-    if let Some(op) = ops.first() {
-        old_cursor = op.old_range().start;
-        new_cursor = op.new_range().start;
-    }
 
     for op in ops.iter_mut() {
         match op {
@@ -288,6 +287,9 @@ where
             (DiffTag::Insert, DiffTag::Delete) | (DiffTag::Delete, DiffTag::Insert) => {
                 ops.swap(pointer - 1, pointer);
                 pointer -= 1;
+                // The swap leaves both ops with stale cursors; renormalize
+                // so the next iteration reads live ranges.
+                normalize_diff_op_cursors(ops);
             }
             // Merge the two ranges
             (DiffTag::Insert, DiffTag::Insert) => {
@@ -376,10 +378,14 @@ where
                     {
                         ops[pointer - 1].grow_right(prefix_len);
                     } else {
+                        // The new Equal goes BEFORE this Delete, at the
+                        // current running cursor -- which is this_op's start
+                        // in both old and new. `next_op.old_range().start` is
+                        // tempting but points past the Delete in old.
                         ops.insert(
                             pointer,
                             DiffOp::Equal {
-                                old_index: next_op.old_range().start,
+                                old_index: this_op.old_range().start,
                                 new_index: this_op.new_range().start,
                                 len: prefix_len,
                             },
@@ -403,6 +409,9 @@ where
             (DiffTag::Insert, DiffTag::Delete) | (DiffTag::Delete, DiffTag::Insert) => {
                 ops.swap(pointer, pointer + 1);
                 pointer += 1;
+                // The swap leaves both ops with stale cursors; renormalize
+                // so the next iteration reads live ranges.
+                normalize_diff_op_cursors(ops);
             }
             // Merge the two ranges
             (DiffTag::Insert, DiffTag::Insert) => {

--- a/src/algorithms/histogram.rs
+++ b/src/algorithms/histogram.rs
@@ -235,7 +235,7 @@ where
             }
             SearchResult::None => {
                 d.delete(old_range.start, old_range.len(), new_range.start)?;
-                d.insert(old_range.start, new_range.start, new_range.len())?;
+                d.insert(old_range.end, new_range.start, new_range.len())?;
             }
             SearchResult::Fallback => {
                 let mut myers_hook = NoFinishHook::new(&mut *d);

--- a/src/common.rs
+++ b/src/common.rs
@@ -421,3 +421,224 @@ fn test_myers_unbalanced_regressions() {
         }));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+//
+// These tests target `diff_slices` so that every shipped `Algorithm` and
+// every shipped `DiffHook` composition can be exercised against the same
+// invariants:
+//
+// 1. The captured `DiffOp`s tile both inputs: the first op starts at
+//    `(0, 0)`, every subsequent op begins exactly where the previous op
+//    ended, and the last op ends at `(old.len(), new.len())`.
+// 2. Every `DiffOp::Equal` names actually-equal slices of the two inputs.
+// 3. Applying the ops to `old` reconstructs `new` exactly.
+
+#[cfg(test)]
+mod proptests {
+    use proptest::prelude::*;
+    use crate::algorithms::{Algorithm, Capture, Compact, Replace, diff_slices};
+    use crate::DiffOp;
+
+    #[derive(Debug, Clone, Copy)]
+    enum HookPipeline {
+        Capture,
+        Replace,
+        Compact,
+        /// `Replace<Compact<Capture>>` -- the pipeline `TextDiff` uses.
+        CompactThenReplace,
+        /// `Compact<Replace<Capture>>` -- compaction over `Replace`'s output.
+        ReplaceThenCompact,
+    }
+
+    fn pipeline_strategy() -> impl Strategy<Value = HookPipeline> {
+        prop_oneof![
+            Just(HookPipeline::Capture),
+            Just(HookPipeline::Replace),
+            Just(HookPipeline::Compact),
+            Just(HookPipeline::CompactThenReplace),
+            Just(HookPipeline::ReplaceThenCompact),
+        ]
+    }
+
+    fn algorithm_strategy() -> impl Strategy<Value = Algorithm> {
+        prop_oneof![
+            Just(Algorithm::Myers),
+            Just(Algorithm::Patience),
+            Just(Algorithm::Lcs),
+            Just(Algorithm::Hunt),
+            Just(Algorithm::Histogram),
+        ]
+    }
+
+    fn run_pipeline<T>(alg: Algorithm, pipeline: HookPipeline, old: &[T], new: &[T]) -> Vec<DiffOp>
+    where
+        T: Eq + core::hash::Hash,
+    {
+        match pipeline {
+            HookPipeline::Capture => {
+                let mut hook = Capture::new();
+                diff_slices(alg, &mut hook, old, new).unwrap();
+                hook.into_ops()
+            }
+            HookPipeline::Replace => {
+                let mut hook = Replace::new(Capture::new());
+                diff_slices(alg, &mut hook, old, new).unwrap();
+                hook.into_inner().into_ops()
+            }
+            HookPipeline::Compact => {
+                let mut hook = Compact::new(Capture::new(), old, new);
+                diff_slices(alg, &mut hook, old, new).unwrap();
+                hook.into_inner().into_ops()
+            }
+            HookPipeline::CompactThenReplace => {
+                let mut hook = Replace::new(Compact::new(Capture::new(), old, new));
+                diff_slices(alg, &mut hook, old, new).unwrap();
+                hook.into_inner().into_inner().into_ops()
+            }
+            HookPipeline::ReplaceThenCompact => {
+                let mut hook = Compact::new(Replace::new(Capture::new()), old, new);
+                diff_slices(alg, &mut hook, old, new).unwrap();
+                hook.into_inner().into_inner().into_ops()
+            }
+        }
+    }
+
+    fn check_invariants<T: Eq + core::fmt::Debug>(
+        ops: &[DiffOp],
+        old: &[T],
+        new: &[T],
+    ) -> Result<(), String> {
+        if ops.is_empty() {
+            if old.is_empty() && new.is_empty() {
+                return Ok(());
+            }
+            return Err(format!(
+                "empty op sequence but inputs are non-empty: old.len={}, new.len={}",
+                old.len(),
+                new.len()
+            ));
+        }
+
+        let mut old_cursor = 0usize;
+        let mut new_cursor = 0usize;
+        let mut reconstructed: Vec<&T> = Vec::with_capacity(new.len());
+
+        for (idx, op) in ops.iter().enumerate() {
+            match *op {
+                DiffOp::Equal { old_index, new_index, len } => {
+                    if old_index != old_cursor || new_index != new_cursor {
+                        return Err(format!(
+                            "op {idx} {op:?}: expected to start at \
+                             (old={old_cursor}, new={new_cursor})"
+                        ));
+                    }
+                    if old_index + len > old.len() || new_index + len > new.len() {
+                        return Err(format!("op {idx} {op:?}: range out of bounds"));
+                    }
+                    for i in 0..len {
+                        if old[old_index + i] != new[new_index + i] {
+                            return Err(format!(
+                                "op {idx} {op:?}: Equal names unequal slices \
+                                 at offset {i}: {:?} vs {:?}",
+                                old[old_index + i], new[new_index + i]
+                            ));
+                        }
+                        reconstructed.push(&new[new_index + i]);
+                    }
+                    old_cursor += len;
+                    new_cursor += len;
+                }
+                DiffOp::Delete { old_index, old_len, new_index } => {
+                    if old_index != old_cursor || new_index != new_cursor {
+                        return Err(format!(
+                            "op {idx} {op:?}: expected to start at \
+                             (old={old_cursor}, new={new_cursor})"
+                        ));
+                    }
+                    if old_index + old_len > old.len() {
+                        return Err(format!("op {idx} {op:?}: old range out of bounds"));
+                    }
+                    old_cursor += old_len;
+                }
+                DiffOp::Insert { old_index, new_index, new_len } => {
+                    if old_index != old_cursor || new_index != new_cursor {
+                        return Err(format!(
+                            "op {idx} {op:?}: expected to start at \
+                             (old={old_cursor}, new={new_cursor})"
+                        ));
+                    }
+                    if new_index + new_len > new.len() {
+                        return Err(format!("op {idx} {op:?}: new range out of bounds"));
+                    }
+                    for v in &new[new_index..new_index + new_len] {
+                        reconstructed.push(v);
+                    }
+                    new_cursor += new_len;
+                }
+                DiffOp::Replace { old_index, old_len, new_index, new_len } => {
+                    if old_index != old_cursor || new_index != new_cursor {
+                        return Err(format!(
+                            "op {idx} {op:?}: expected to start at \
+                             (old={old_cursor}, new={new_cursor})"
+                        ));
+                    }
+                    if old_index + old_len > old.len() || new_index + new_len > new.len() {
+                        return Err(format!("op {idx} {op:?}: range out of bounds"));
+                    }
+                    for v in &new[new_index..new_index + new_len] {
+                        reconstructed.push(v);
+                    }
+                    old_cursor += old_len;
+                    new_cursor += new_len;
+                }
+            }
+        }
+
+        if old_cursor != old.len() || new_cursor != new.len() {
+            return Err(format!(
+                "ops do not cover full inputs: ended at (old={old_cursor}, \
+                 new={new_cursor}), expected ({}, {})",
+                old.len(),
+                new.len()
+            ));
+        }
+
+        let new_refs: Vec<&T> = new.iter().collect();
+        if reconstructed != new_refs {
+            return Err(format!(
+                "reconstruction mismatch: got {reconstructed:?}, expected {new_refs:?}"
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn small_seq() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(0u8..4, 0..12)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 10000,
+            ..ProptestConfig::default()
+        })]
+
+        #[test]
+        fn diff_slices_satisfies_contract(
+            alg in algorithm_strategy(),
+            pipeline in pipeline_strategy(),
+            old in small_seq(),
+            new in small_seq(),
+        ) {
+            let ops = run_pipeline(alg, pipeline, &old, &new);
+            if let Err(msg) = check_invariants(&ops, &old, &new) {
+                return Err(TestCaseError::fail(format!(
+                    "{alg:?} + {pipeline:?} on old={old:?} new={new:?}: {msg}\nops={ops:#?}"
+                )));
+            }
+        }
+    }
+}

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1167,6 +1167,29 @@ fn test_regression_issue_37() {
     let mut output = diff.unified_diff();
     assert_eq!(
         output.context_radius(0).to_string(),
-        "@@ -1 +1,0 @@\n-\u{18}\n@@ -2,0 +2,2 @@\n+\n+\r"
+        "@@ -1 +0,0 @@\n-\u{18}\n@@ -2,0 +2,2 @@\n+\n+\r"
+    );
+}
+
+#[test]
+fn test_regression_issue_95() {
+    let diff = TextDiff::from_lines("d\na\nc\nb\na\na", "b\nd\nd\na\nd");
+    let changes = diff
+        .iter_all_changes()
+        .map(|c| (c.tag(), c.value().to_string()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        changes,
+        vec![
+            (ChangeTag::Insert, "b\n".into()),
+            (ChangeTag::Insert, "d\n".into()),
+            (ChangeTag::Equal, "d\n".into()),
+            (ChangeTag::Equal, "a\n".into()),
+            (ChangeTag::Delete, "c\n".into()),
+            (ChangeTag::Delete, "b\n".into()),
+            (ChangeTag::Delete, "a\n".into()),
+            (ChangeTag::Delete, "a".into()),
+            (ChangeTag::Insert, "d".into()),
+        ],
     );
 }


### PR DESCRIPTION
I did some follow-up work on https://github.com/mitsuhiko/similar/issues/95 to port the proptests I already had in my own calling library code to similar itself. I had Opus analyze and fix the bugs it found. I did not manually confirm its analysis, but it seems plausible to me.

The second fix (for #95) changes the runtime complexity in a meaningful way. If needed I can try to optimize it