### PR TITLE
Fix empty input diffs

### DIFF
--- a/src/algorithms/hunt.rs
+++ b/src/algorithms/hunt.rs
@@ -155,6 +155,10 @@ where
     New: Index<usize, Output = usize> + ?Sized,
     D: DiffHook,
 {
+    if is_empty_range(&old_range) && is_empty_range(&new_range) {
+        d.finish()?;
+        return Ok(());
+    }
     if is_empty_range(&new_range) {
         d.delete(old_range.start, old_range.len(), new_range.start)?;
         d.finish()?;

--- a/src/algorithms/lcs.rs
+++ b/src/algorithms/lcs.rs
@@ -112,6 +112,10 @@ where
     D: DiffHook,
     New::Output: PartialEq<Old::Output>,
 {
+    if is_empty_range(&old_range) && is_empty_range(&new_range) {
+        d.finish()?;
+        return Ok(());
+    }
     if is_empty_range(&new_range) {
         d.delete(old_range.start, old_range.len(), new_range.start)?;
         d.finish()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -451,3 +451,16 @@ fn test_remapper() {
     assert_eq!(remap.slice(0..5), Some("foo bar baz"));
     assert_eq!(remap.slice(0..6), None);
 }
+
+#[test]
+fn test_empty_diff() {
+    for algorithm in [Algorithm::Lcs, Algorithm::Hunt] {
+        let diff = TextDiff::configure()
+            .algorithm(algorithm)
+            .diff_chars("", "");
+        assert!(diff.ops().is_empty());
+        assert!(diff_chars(algorithm, "", "").is_empty());
+        assert!(diff_words(algorithm, "", "").is_empty());
+        assert!(diff_lines(algorithm, "", "").is_empty());
+    }
+}


### PR DESCRIPTION
Handle empty ranges before building the LCS and Hunt matrices.

This keeps empty-vs-empty text and slice diffs from panicking.

Fixes #99

Tests:
- `cargo test --all-features`
- `cargo check --no-default-features`
- `cargo fmt --check`